### PR TITLE
Remove port forcing in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,4 +65,4 @@ ENV PORT 80
 
 # server.js is created by next build from the standalone output
 # https://nextjs.org/docs/pages/api-reference/next-config-js/output
-CMD HOSTNAME="0.0.0.0" node server.js
+CMD node server.js


### PR DESCRIPTION
Non-privileged user (not root) can't open a listening socket on ports below 1024. (https://stackoverflow.com/a/60373143/17836168)

```
 ⨯ Failed to start server
Error: listen EACCES: permission denied 0.0.0.0:80
    at Server.setupListenHandle [as _listen2] (node:net:1800:21)
    at listenInCluster (node:net:1865:12)
    at doListen (node:net:2014:7)
    at process.processTicksAndRejections (node:internal/process/task_queues:83:21) {
  code: 'EACCES',
  errno: -13,
  syscall: 'listen',
  address: '0.0.0.0',
  port: 80
}
```